### PR TITLE
fix unused result warning/error for fread

### DIFF
--- a/src/core/file.h
+++ b/src/core/file.h
@@ -61,7 +61,12 @@ FileReadResult File_read(const char* filename, int is_text_file)
     fseek(file, 0, SEEK_SET);
 
     result.data_owned = (u8*)malloc(result.size + (is_text_file == 0 ? 0 : 1));
-    fread(result.data_owned, 1, result.size, file);
+    if(fread(result.data_owned, 1, result.size, file) != result.size)
+    {
+    	log_error("Unable to read file '%s'\n", filename);
+	fclose(file);
+	exit(1);
+    }
     fclose(file);
     if (is_text_file != 0) {
         result.data_owned[result.size] = 0;


### PR DESCRIPTION
compile fails with unused result warning as error on:
```sh
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-pc-linux-gnu/14/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /var/tmp/portage/sys-devel/gcc-14.2.1_p20241102/work/gcc-14-20241102/configure --host=x86_64-pc-linux-gnu --build=x86_64-pc-linux-gnu --prefix=/usr --bindir=/usr/x86_64-pc-linux-gnu/gcc-bin/14 --includedir=/usr/lib/gcc/x86_64-pc-linux-gnu/14/include --datadir=/usr/share/gcc-data/x86_64-pc-linux-gnu/14 --mandir=/usr/share/gcc-data/x86_64-pc-linux-gnu/14/man --infodir=/usr/share/gcc-data/x86_64-pc-linux-gnu/14/info --with-gxx-include-dir=/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14 --disable-silent-rules --disable-dependency-tracking --with-python-dir=/share/gcc-data/x86_64-pc-linux-gnu/14/python --enable-objc-gc --enable-languages=c,c++,d,go,objc,obj-c++,fortran,ada,m2,rust --enable-obsolete --enable-secureplt --disable-werror --with-system-zlib --enable-nls --without-included-gettext --disable-libunwind-exceptions --enable-checking=release --with-bugurl=https://bugs.gentoo.org/ --with-pkgversion='Gentoo 14.2.1_p20241102 p3' --with-gcc-major-version-only --enable-libstdcxx-time --enable-lto --disable-libstdcxx-pch --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-multilib --with-multilib-list=m32,m64 --disable-fixed-point --enable-targets=all --enable-libgomp --disable-libssp --enable-libada --enable-cet --disable-systemtap --disable-valgrind-annotations --enable-vtable-verify --with-zstd --with-isl --disable-isl-version-check --enable-default-pie --enable-host-pie --enable-host-bind-now --enable-default-ssp --disable-fixincludes --with-build-config='bootstrap-O3 bootstrap-lto bootstrap-cet'
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 14.2.1 20241102 (Gentoo 14.2.1_p20241102 p3) 
glibc-2.40-r5
linux-6.11.6
```