### PR TITLE
fix linux building: bump cmake_minimum_required to 3.10 for src/vendor/freetype

### DIFF
--- a/src/vendor/freetype/CMakeLists.txt
+++ b/src/vendor/freetype/CMakeLists.txt
@@ -110,7 +110,7 @@
 
 # To minimize the number of cmake_policy() workarounds,
 # CMake >= 3 is requested.
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 if (NOT CMAKE_VERSION VERSION_LESS 3.3)
   # Allow symbol visibility settings also on static libraries. CMake < 3.3


### PR DESCRIPTION
Hi Ge and Andrew,

I noticed a cmake building error on (arch)linux that it requires at least cmake 3.5 and, preferably, 3.10 due to deprecation settings.
```
CMake Error at vendor/freetype/CMakeLists.txt:113 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

CMake Deprecation Warning at vendor/freetype/CMakeLists.txt:113 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

I tried bumping the version to 3.10 and then it built fine.